### PR TITLE
Disabled annotation scanning for JSF tags in web.xml

### DIFF
--- a/ninja-rythm-demo/src/main/webapp/WEB-INF/web.xml
+++ b/ninja-rythm-demo/src/main/webapp/WEB-INF/web.xml
@@ -20,7 +20,8 @@
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-         version="3.0">
+         version="3.0"         
+         metadata-complete="true">
 
     <display-name>ninja</display-name>
 


### PR DESCRIPTION
Makes reloads of Jetty 9 A LOT faster.
